### PR TITLE
Update compatible .Net version

### DIFF
--- a/source/includes/compatibility-table.rst
+++ b/source/includes/compatibility-table.rst
@@ -8,4 +8,4 @@
 
    * - **{+version-number+}**
      - **7.0**
-     - **6.0 or later**
+     - **7.0 or later**


### PR DESCRIPTION
Updating compatible .NET version to 7.0 instead of 6.0

Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/entity-framework/compatibility-version-update/