### PR TITLE
DOCSP-41879 Clarify SaveChanges is transactional

### DIFF
--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -46,8 +46,8 @@ rolls back any changes made to the database. Because of this, your application
 must be connected to a transaction-capable deployment of MongoDB server, such as
 a replica set.
 
-You can disable automatic transactions in ``SaveChanges()`` and
-``SaveChangesAsync()`` by setting the ``AutoTransactionBehavior`` property to
+You can disable automatic transactions in the ``SaveChanges()`` and
+``SaveChangesAsync()`` methods by setting the ``AutoTransactionBehavior`` property to
 ``AutoTransaction.Never`` on your ``DbContext`` subclass during application
 setup. However, we do not recommend disabling this feature. Doing so causes
 any concurrency changes or operation failures during the save operation

--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -60,6 +60,11 @@ The following example shows how to disable automatic transactions in the
 
    dbContext.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 
+.. warning::
+
+   Disabling automatic transactions can lead to data inconsistencies. We
+   recommend that you do not disable this feature.
+
 Insert
 ------
 

--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -33,9 +33,13 @@ The ``SaveChanges()`` and ``SaveChangesAsync()`` methods are transactional by
 default. This means that if an error occurs during the operation, the provider
 rolls back any changes made to the database. Because of this, your application
 must be connected to a transaction-capable instance of a MongoDB server, such as
-a replica set. You can disable transactions during write operations bt setting the ``Database.AutoTransactionBehavior =
-AutoTrasactionBehavior.Never`` on your ``DbContext`` subclass during your
-application setup.
+a replica set. You can disable transactions during write operations by setting
+the ``AutoTransactionBehavior`` property to ``AutoTransaction.Never`` on your
+``DbContext`` subclass during application setup, as shown in the following example:
+
+.. code-block:: csharp
+
+   dbContext.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 
 In this guide, you can see examples of how to perform common write operations on
 an application configured to use the {+provider-short+}.

--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -30,7 +30,7 @@ any changes made to your data and runs the necessary commands to update the
 database by using the MongoDB Query API.
 
 The ``SaveChanges()`` and ``SaveChangesAsync()`` methods are transactional by
-default. This means that if an error occurs during the operation, the provider
+default. This means that if an error occurs during an operation, the provider
 rolls back any changes made to the database. Because of this, your application
 must be connected to a transaction-capable instance of a MongoDB server, such as
 a replica set. You can disable transactions during write operations by setting
@@ -41,13 +41,13 @@ the ``AutoTransactionBehavior`` property to ``AutoTransaction.Never`` on your
 
    dbContext.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 
-In this guide, you can see examples of how to perform common write operations on
-an application configured to use the {+provider-short+}.
-
 .. tip::
 
    To learn how to configure an application to use the {+provider-short+}, see
    :ref:`entity-framework-configure`.
+
+In this guide, you can see examples of how to perform common write operations on
+an application configured to use the {+provider-short+}.
 
 Insert
 ------

--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -29,34 +29,42 @@ When you call the ``SaveChanges()`` or ``SaveChangesAsync()`` method, the {+prov
 any changes made to your data and runs the necessary commands to update the
 database by using the MongoDB Query API.
 
-The ``SaveChanges()`` and ``SaveChangesAsync()`` methods are transactional by
-default. This means that if an error occurs during an operation, the provider
-rolls back any changes made to the database. Because of this, your application
-must be connected to a transaction-capable deployment of MongoDB server, such as
-a replica set.
-
-You can disable transactions during write operations by setting
-the ``AutoTransactionBehavior`` property to ``AutoTransaction.Never`` on your
-``DbContext`` subclass during application setup, as shown in the following example:
-
-.. code-block:: csharp
-
-   dbContext.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+In this guide, you can see examples of how to perform common write operations on
+an application configured to use the {+provider-short+}.
 
 .. tip::
 
    To learn how to configure an application to use the {+provider-short+}, see
    :ref:`entity-framework-configure`.
 
-In this guide, you can see examples of how to perform common write operations on
-an application configured to use the {+provider-short+}.
+Transactional Write Operations
+-------------------------------
+
+The ``SaveChanges()`` and ``SaveChangesAsync()`` methods are transactional by
+default. This means that if an error occurs during an operation, the provider
+rolls back any changes made to the database. Because of this, your application
+must be connected to a transaction-capable deployment of MongoDB server, such as
+a replica set.
+
+You can disable automatic transactions in ``SaveChanges()`` and
+``SaveChangesAsync()`` by setting the ``AutoTransactionBehavior`` property to
+``AutoTransaction.Never`` on your ``DbContext`` subclass during application
+setup. However, we do not recommend disabling this feature. Doing so causes
+any concurrency changes or operation failures during the save operation
+to leave the database in an inconsistent state.
+
+The following example shows how to disable automatic transactions in the
+``SaveChanges()`` and ``SaveChangesAsync()`` methods:
+
+.. code-block:: csharp
+
+   dbContext.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 
 Insert
 ------
 
 You can use the ``Add()`` method to insert a single entity into your collection, 
 or you can use the ``AddRange()`` method to insert multiple entities at once. 
-
 
 .. _entity-framework-insert-one:
 

--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -23,11 +23,19 @@ Overview
 {+framework-core+} allows you to work with data in your application without
 explicitly running database commands. You can insert, update, or delete data
 within your application and persist those changes to MongoDB by using the
-``SaveChanges()`` method.
+``SaveChanges()`` or ``SaveChangesAsync()`` method.
 
-When you call the ``SaveChanges()`` method, the {+provider-short+} automatically detects
+When you call the ``SaveChanges()`` or ``SaveChangesAsync()`` method, the {+provider-short+} automatically detects
 any changes made to your data and runs the necessary commands to update the
 database by using the MongoDB Query API.
+
+The ``SaveChanges()`` and ``SaveChangesAsync()`` methods are transactional by
+default. This means that if an error occurs during the operation, the provider
+rolls back any changes made to the database. Because of this, your application
+must be connected to a transaction-capable instance of a MongoDB server, such as
+a replica set. You can disable transactions during write operations bt setting the ``Database.AutoTransactionBehavior =
+AutoTrasactionBehavior.Never`` on your ``DbContext`` subclass during your
+application setup.
 
 In this guide, you can see examples of how to perform common write operations on
 an application configured to use the {+provider-short+}.

--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -32,8 +32,10 @@ database by using the MongoDB Query API.
 The ``SaveChanges()`` and ``SaveChangesAsync()`` methods are transactional by
 default. This means that if an error occurs during an operation, the provider
 rolls back any changes made to the database. Because of this, your application
-must be connected to a transaction-capable instance of a MongoDB server, such as
-a replica set. You can disable transactions during write operations by setting
+must be connected to a transaction-capable deployment of MongoDB server, such as
+a replica set.
+
+You can disable transactions during write operations by setting
 the ``AutoTransactionBehavior`` property to ``AutoTransaction.Never`` on your
 ``DbContext`` subclass during application setup, as shown in the following example:
 

--- a/source/includes/fundamentals/code-examples/configure/ConfigureEFProvider.cs
+++ b/source/includes/fundamentals/code-examples/configure/ConfigureEFProvider.cs
@@ -10,6 +10,7 @@ var dbContextOptions =
     new DbContextOptionsBuilder<MyDbContext>().UseMongoDB(mongoClient, "<Database Name>");
 
 var db = new MyDbContext(dbContextOptions.Options);
+db.Database.EnsureCreated();
 
 // Add a new customer and save it to the database
 db.Customers.Add(new Customer() { name = "John Doe", Order = "1 Green Tea" });

--- a/source/includes/fundamentals/code-examples/configure/UseMongoDB.cs
+++ b/source/includes/fundamentals/code-examples/configure/UseMongoDB.cs
@@ -4,3 +4,4 @@ var dbContextOptions =
     new DbContextOptionsBuilder<MyDbContext>().UseMongoDB(mongoClient, "<Database Name");
 
 var db = new MyDbContext(dbContextOptions.Options);
+db.Database.EnsureCreated();

--- a/source/limitations.txt
+++ b/source/limitations.txt
@@ -64,15 +64,6 @@ supports only the following scalar aggregation operations:
 This version of the {+provider-short+} does not support other scalar aggregation
 operations.
 
-Transactions
-~~~~~~~~~~~~
-
-Transactions ensure that all updates in a set of changes either succeed, or fail
-together so the database is not left in an inconsistent state. 
-
-This version of the {+provider-short+} does not support the {+framework-core+}
-transaction model.
-
 Migrations
 ~~~~~~~~~~
 


### PR DESCRIPTION
# Pull Request Info

This PR also adds a few lines of `EnsureCreated()` where it was missed in a previous PR

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-41879
Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/entity-framework/DOCSP-41879-save-changes-transactional/fundamentals/write-data/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
