### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -16,6 +16,7 @@ FAQ
 
 .. meta::
    :keywords: questions, errors, problems
+   :description: Discover the differences between the .NET/C# Driver and the EF Core Provider for MongoDB, including their features and use cases.
 
 This page contains frequently asked questions and their corresponding answers.
 

--- a/source/fundamentals/configure.txt
+++ b/source/fundamentals/configure.txt
@@ -10,6 +10,7 @@ Configure the {+provider-short+}
 
 .. meta::
    :keywords: EF, EF Core, code example
+   :description: Learn how to configure an application to use the MongoDB Entity Framework Core Provider, including creating POCOs and DB context classes.
 
 .. contents:: On this page
    :local:

--- a/source/fundamentals/query-data.txt
+++ b/source/fundamentals/query-data.txt
@@ -10,6 +10,7 @@ Query Data
 
 .. meta::
    :keywords: EF, EF Core, code example, read
+   :description: Explore how to query data using Entity Framework Core with LINQ syntax, including finding, sorting, and retrieving entities from a MongoDB database.
 
 .. contents:: On this page
    :local:

--- a/source/fundamentals/write-data.txt
+++ b/source/fundamentals/write-data.txt
@@ -10,6 +10,7 @@ Write Data to MongoDB
 
 .. meta::
    :keywords: EF, EF Core, code example, write
+   :description: Perform write operations in MongoDB using Entity Framework Core, including inserting, updating, and deleting data with `SaveChanges()` or `SaveChangesAsync()`.
 
 .. contents:: On this page
    :local:

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,9 @@
 {+provider-long+}
 ========================================
 
+.. meta::
+   :description: Explore the MongoDB Entity Framework Core Provider to integrate MongoDB with .NET applications using Entity Framework Core for data access and manipulation.
+
 .. toctree::
 
    Quick Start </quick-start>

--- a/source/issues-and-help.txt
+++ b/source/issues-and-help.txt
@@ -4,6 +4,9 @@
 Issues & Help
 =============
 
+.. meta::
+   :description: Report bugs or request features for the EF Core Provider by creating an issue in JIRA, and follow instructions for reporting security vulnerabilities.
+
 Bugs / Feature Requests
 -----------------------
 

--- a/source/limitations.txt
+++ b/source/limitations.txt
@@ -16,6 +16,7 @@ Limitations
 
 .. meta:: 
    :keywords: EF, EF Core, support
+   :description: Discover the limitations of the EF Core Provider for MongoDB, including unsupported features like select projections, migrations, and time series data.
 
 Overview
 --------

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -4,6 +4,9 @@
 Quick Reference
 ===============
 
+.. meta::
+   :description: Explore provider syntax for various commands in Entity Framework, including configuring a DBContext, finding, inserting, updating, and deleting entities.
+
 This page shows the provider syntax for several commands and links to
 their related API documentation.
 

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -10,6 +10,7 @@ Quick Start
 
 .. meta::
    :keywords: set up, runnable app, initialize, connect, code example
+   :description: Create a .NET application using the EF Core Provider to connect to a MongoDB Atlas cluster, set up a project, and query sample data.
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539